### PR TITLE
Update broken changelog link

### DIFF
--- a/packageManifest.json
+++ b/packageManifest.json
@@ -7,7 +7,7 @@
     "documentationLink": "https://github.com/tonesto7/homebridge-hubitat-tonesto7#readme",
     "communityLink": "https://community.hubitat.com/t/release-homebridge-hubitat-v2-0/54056",
     "licenseFile": "",
-    "releaseNotes": "Please see Changelog at https://raw.githubusercontent.com/tonesto7/homebridge-hubitat-tonesto7/master/changelog-app.md for recent changes.",
+    "releaseNotes": "Please see Changelog at https://raw.githubusercontent.com/tonesto7/homebridge-hubitat-tonesto7/master/CHANGELOG-app.md for recent changes.",
     "apps": [{
         "id": "d355b1b6-148e-4a67-a1b0-3e570ad1b6b5",
         "name": "Homebridge v2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of Changes

I changed `https://raw.githubusercontent.com/tonesto7/homebridge-hubitat-tonesto7/master/changelog-app.md` to `https://raw.githubusercontent.com/tonesto7/homebridge-hubitat-tonesto7/master/CHANGELOG-app.md` in `package-manifest.json`.

## Reason for Change

The link to the changelog in Package Manager when an update completes was broken.

## How Has This Been Tested?

It hasn't -- simple typo fix.

## Screenshots (if appropriate):

N/A

---

Thank you for all of your work!! Happy New Year.